### PR TITLE
Stronger typing, and snippet completion

### DIFF
--- a/vscode-swift-language-server/src/server.ts
+++ b/vscode-swift-language-server/src/server.ts
@@ -7,14 +7,8 @@
 import { execFile } from 'child_process';
 
 import {
-	SwiftType,
-	SwiftCompletionSuggestion,
-	completionKindForSwiftType,
-	symbolKindForSwiftType,
-	Decl,
 	Swift,
-	DeclFunction,
-	DeclVar
+	SwiftCompletionSuggestion,
 } from './swiftSourceTypes';
 
 import {
@@ -87,10 +81,15 @@ connection.onCompletion((textDocumentPosition: TextDocumentPositionParams): Then
 					item.detail = `${suggestion.moduleName}.${suggestion.typeName}`;
 					item.documentation = suggestion.docBrief;
 					// default types
-					item.kind = completionKindForSwiftType(suggestion.kind);
+					item.kind = Swift.completionKindForSwiftType(suggestion.kind);
+
+					let snippet = createSnippet(suggestion);
+
 					// overrides
+					console.log(suggestion.kind);
+
 					switch (suggestion.kind) {
-						case Decl.Module:
+						case Swift.DeclModule:
 							item.kind = CompletionItemKind.Module;
 							break;
 						case Swift.Keyword:
@@ -98,36 +97,36 @@ connection.onCompletion((textDocumentPosition: TextDocumentPositionParams): Then
 							item.documentation = '';
 							item.kind = CompletionItemKind.Keyword;
 							break;
-						case DeclFunction.Free:
+						case Swift.DeclFunctionFree:
 							item.kind = CompletionItemKind.Function;
 							break;
-						case DeclVar.Instance:
-						case DeclVar.Global:
+						case Swift.DeclVarInstance:
+						case Swift.DeclVarGlobal:
 							item.kind = CompletionItemKind.Variable;
 							break;
-						case Decl.Protocol:
+						case Swift.DeclProtocol:
 							item.kind = CompletionItemKind.Interface;
 							break;
-						case Decl.Class:
+						case Swift.DeclClass:
 							item.kind = CompletionItemKind.Class;
 							break;
-						case Decl.Struct:
+						case Swift.DeclStruct:
 							item.kind = CompletionItemKind.Value;
 							break;
-						case DeclFunction.Constructor:
+						case Swift.DeclFunctionConstructor:
 							item.kind = CompletionItemKind.Constructor;
 							item.insertText = suggestion.sourcetext;
 							item.documentation = suggestion.descriptionKey;
+							// remove leading and trailing parens
+							snippet = snippet.substr(1, snippet.length - 2)
 							break;
-						case Decl.Enum:
+						case Swift.DeclEnum:
 							item.kind = CompletionItemKind.Enum;
 							break;
-						case Decl.Typealias:
+						case Swift.DeclTypealias:
 							item.kind = CompletionItemKind.Reference;
 							break;
 					}
-
-					let snippet = createSnippet(suggestion);
 					if (snippet.length != suggestion.sourcetext.length) {
 						item.insertText = snippet;
 					}

--- a/vscode-swift-language-server/src/server.ts
+++ b/vscode-swift-language-server/src/server.ts
@@ -127,6 +127,10 @@ connection.onCompletion((textDocumentPosition: TextDocumentPositionParams): Then
 							break;
 					}
 
+					let snippet = createSnippet(suggestion);
+					if (snippet.length != suggestion.sourcetext.length) {
+						item.insertText = snippet;
+					}
 					return item;
 				});
 				resolve(items);
@@ -158,6 +162,7 @@ connection.onDocumentSymbol((documentSymbolParams: DocumentSymbolParams): Thenab
 						kind: 3,
 						location: symbolLocation
 					};
+					// TODO use swift types?
 					switch (value['key.kind']) {
 						case 'source.lang.swift.decl.var.global':
 							symbol.kind = SymbolKind.Variable;
@@ -189,3 +194,19 @@ connection.onDocumentSymbol((documentSymbolParams: DocumentSymbolParams): Thenab
 
 // Listen on the connection
 connection.listen();
+
+// Helpers
+
+/**
+ * Creates a snippet formatted string with cursor positions from sourcekit sourcetext
+ *
+ * @param {SwiftCompletionSuggestion} suggestion
+ * @returns {string}
+ */
+function createSnippet(suggestion: SwiftCompletionSuggestion): string {
+	let cursorIndex = 1
+	const replacer = suggestion.sourcetext.replace(/<#T##(.+?)#>/g, (_, group) => {
+		return `\{{${cursorIndex++}:${group.split('##')[0]}}}`;
+	});
+	return replacer.replace('<#code#>', `\{{${cursorIndex++}}}`);
+};

--- a/vscode-swift-language-server/src/swiftSourceTypes.ts
+++ b/vscode-swift-language-server/src/swiftSourceTypes.ts
@@ -4,7 +4,7 @@ import 	{ SymbolKind, CompletionItemKind,
 /**
  *  Bindings for SourceKit type definitions
  */
-export enum Keyword {
+export enum Swift {
     Keyword, 'source.lang.swift.keyword',
 };
 export enum Decl {
@@ -83,7 +83,7 @@ export enum SyntaxtypeAttribute {
 };
 
 export type SwiftType =
-    Keyword |
+    Swift |
     Decl |
     DeclExtension |
     DeclFunction |
@@ -167,7 +167,7 @@ export function symbolKindForSwiftType(swiftType: SwiftType): SymbolKind {
             return SymbolKind.Interface;
 
 // no super applicable types for these:
-        case Keyword.Keyword:
+        case Swift.Keyword:
         case Syntaxtype.Keyword:
         case SyntaxtypeAttribute.Builtin:
         case Syntaxtype.Comment:
@@ -192,7 +192,7 @@ export function completionKindForSwiftType(swiftType: SwiftType): CompletionItem
 // high confidence
         case Decl.Module:
             return CompletionItemKind.Module;
-        case Keyword.Keyword:
+        case Swift.Keyword:
         case Syntaxtype.Keyword:
             return CompletionItemKind.Keyword;
         case SyntaxtypeAttribute.Builtin:

--- a/vscode-swift-language-server/src/swiftSourceTypes.ts
+++ b/vscode-swift-language-server/src/swiftSourceTypes.ts
@@ -1,306 +1,291 @@
-import 	{ SymbolKind, CompletionItemKind,
+import { SymbolKind, CompletionItemKind,
 } from 'vscode-languageserver';
 
 /**
  *  Bindings for SourceKit type definitions
  */
-export enum Swift {
-    Keyword, 'source.lang.swift.keyword',
-};
-export enum Decl {
-    Associatedtype, 'source.lang.swift.decl.associatedtype',
-    Class, 'source.lang.swift.decl.class',
-    Enum, 'source.lang.swift.decl.enum',
-    Enumelement, 'source.lang.swift.decl.enumelement',
-    GenericTypeParam, 'source.lang.swift.decl.generic_type_param',
-    Protocol, 'source.lang.swift.decl.protocol',
-    Struct, 'source.lang.swift.decl.struct',
-    Typealias, 'source.lang.swift.decl.typealias',
-    Module, 'source.lang.swift.decl.module',
-};
-export enum DeclExtension {
-    Class, 'source.lang.swift.decl.extension.class',
-};
-export enum DeclFunction {
-    Constructor, 'source.lang.swift.decl.function.constructor',
-    Free, 'source.lang.swift.decl.function.free',
-    Subscript, 'source.lang.swift.decl.function.subscript',
-};
-export enum DeclFunctionOperator {
-    Infix, 'source.lang.swift.decl.function.operator.infix',
-};
-export enum DeclFunctionAccessor {
-    Getter, 'source.lang.swift.decl.function.accessor.getter',
-    Setter, 'source.lang.swift.decl.function.accessor.setter',
-};
-export enum DeclFunctionMethod {
-    Class, 'source.lang.swift.decl.function.method.class',
-    Instance, 'source.lang.swift.decl.function.method.instance',
-    Static, 'source.lang.swift.decl.function.method.static',
-};
-export enum DeclVar {
-    Global, 'source.lang.swift.decl.var.global',
-    Instance, 'source.lang.swift.decl.var.instance',
-    Local, 'source.lang.swift.decl.var.local',
-};
-export enum Ref {
-    Associatedtype, 'source.lang.swift.ref.associatedtype',
-    Class, 'source.lang.swift.ref.class',
-    Enum, 'source.lang.swift.ref.enum',
-    Enumelement, 'source.lang.swift.ref.enumelement',
-    GenericTypeParam, 'source.lang.swift.ref.generic_type_param',
-    Protocol, 'source.lang.swift.ref.protocol',
-    Struct, 'source.lang.swift.ref.struct',
-    Typealias, 'source.lang.swift.ref.typealias',
-};
-export enum RefFunction {
-    Constructor, 'source.lang.swift.ref.function.constructor',
-    Free, 'source.lang.swift.ref.function.free',
-    Subscript, 'source.lang.swift.ref.function.subscript',
-};
-export enum RefFunctionMethod {
-    Class, 'source.lang.swift.ref.function.method.class',
-    Instance, 'source.lang.swift.ref.function.method.instance',
-};
-export enum RefFunctionOperator {
-    Infix, 'source.lang.swift.ref.function.operator.infix'
-};
-export enum RefVar {
-    Global, 'source.lang.swift.ref.var.global',
-    Instance, 'source.lang.swift.ref.var.instance',
-    Local, 'source.lang.swift.ref.var.local',
-};
-export enum Syntaxtype {
-    Argument, 'source.lang.swift.syntaxtype.argument',
-    Comment, 'source.lang.swift.syntaxtype.comment',
-    Identifier, 'source.lang.swift.syntaxtype.identifier',
-    Keyword, 'source.lang.swift.syntaxtype.keyword',
-    Number, 'source.lang.swift.syntaxtype.number',
-    Parameter, 'source.lang.swift.syntaxtype.parameter',
-};
-export enum SyntaxtypeAttribute {
-    Builtin, 'source.lang.swift.syntaxtype.attribute.builtin',
-};
+export declare namespace Swift {
 
-export type SwiftType =
-    Swift |
-    Decl |
-    DeclExtension |
-    DeclFunction |
-    DeclFunctionOperator |
-    DeclFunctionAccessor |
-    DeclFunctionMethod |
-    DeclVar |
-    Ref |
-    RefFunction |
-    RefFunctionMethod |
-    RefFunctionOperator |
-    RefVar |
-    Syntaxtype |
-    SyntaxtypeAttribute;
+    let Keyword: 'source.lang.swift.keyword';
+    let DeclAssociatedtype: 'source.lang.swift.decl.associatedtype';
+    let DeclClass: 'source.lang.swift.decl.class';
+    let DeclEnum: 'source.lang.swift.decl.enum';
+    let DeclEnumelement: 'source.lang.swift.decl.enumelement';
+    let DeclGenericTypeParam: 'source.lang.swift.decl.generic_type_param';
+    let DeclProtocol: 'source.lang.swift.decl.protocol';
 
-/**
- * Maps SourceKit types to VSCode {SymbolKind}
- * FIXME: kinda limted
- *
- * @export
- * @param {SwiftType} swiftType
- * @returns {SymbolKind}
- */
-export function symbolKindForSwiftType(swiftType: SwiftType): SymbolKind {
-    // not really easy to have an obvious completion kind per type.
-    switch (swiftType) {
-// high confidence
-        case Decl.Module:
-            return SymbolKind.Module;
-        case Decl.Enum:
-        case Decl.Enumelement:
-        case Ref.Enum:
-        case Ref.Enumelement:
-            return SymbolKind.Enum;
-// medium confidence
-        case DeclFunction.Free:
-        case DeclFunction.Subscript:
-        case DeclFunctionOperator.Infix:
-        case RefFunction.Free:
-        case RefFunction.Subscript:
-        case RefFunctionOperator.Infix:
-            return SymbolKind.Function;
-        case DeclFunctionMethod.Class:
-        case DeclFunctionMethod.Static:
-        case DeclFunctionMethod.Instance:
-            return SymbolKind.Method;
-        case DeclFunction.Constructor:
-        case RefFunction.Constructor:
-            return SymbolKind.Constructor;
-        case DeclFunctionAccessor.Getter:
-        case DeclFunctionAccessor.Setter:
-            return SymbolKind.Field;
-        case Decl.Associatedtype:
-        case Decl.Class:
-        case Decl.Struct:
-        case DeclExtension.Class:
-        case Ref.Class:
-        case Ref.Struct:
-            return SymbolKind.Class;
-        case RefFunctionMethod.Class:
-        case RefFunctionMethod.Instance:
-            return SymbolKind.Method;
-// low confidence
-        case DeclVar.Global:
-        case DeclVar.Instance:
-        case DeclVar.Local:
-        case RefVar.Global:
-        case RefVar.Instance:
-        case RefVar.Local:
-            return SymbolKind.Variable;
-        case Syntaxtype.Argument:
-        case Syntaxtype.Parameter:
-            return SymbolKind.Field;
-        case Ref.Associatedtype:
-        case Decl.GenericTypeParam:
-        case Ref.GenericTypeParam:
-        case Ref.Protocol:
-        case Ref.Typealias:
-        case Decl.Protocol:
-        case Decl.Typealias:
-            return SymbolKind.Interface;
+    let DeclStruct: 'source.lang.swift.decl.struct';
+    let DeclTypealias: 'source.lang.swift.decl.typealias';
+    let DeclModule: 'source.lang.swift.decl.module';
+    let DeclExtensionClass: 'source.lang.swift.decl.extension.class';
+    let DeclFunctionConstructor: 'source.lang.swift.decl.function.constructor';
+    let DeclFunctionFree: 'source.lang.swift.decl.function.free';
+    let DeclFunctionSubscript: 'source.lang.swift.decl.function.subscript';
 
-// no super applicable types for these:
-        case Swift.Keyword:
-        case Syntaxtype.Keyword:
-        case SyntaxtypeAttribute.Builtin:
-        case Syntaxtype.Comment:
-        case Syntaxtype.Identifier:
-        case Syntaxtype.Number:
-            console.log("no match for " + swiftType);
+    let DeclFunctionOperatorInfix: 'source.lang.swift.decl.function.operator.infix';
+
+    let DeclFunctionAccessorGetter: 'source.lang.swift.decl.function.accessor.getter';
+    let DeclFunctionAccessorSetter: 'source.lang.swift.decl.function.accessor.setter';
+
+    let DeclFunctionMethodClass: 'source.lang.swift.decl.function.method.class';
+    let DeclFunctionMethodInstance: 'source.lang.swift.decl.function.method.instance';
+    let DeclFunctionMethodStatic: 'source.lang.swift.decl.function.method.static';
+
+    let DeclVarGlobal: 'source.lang.swift.decl.var.global';
+    let DeclVarInstance: 'source.lang.swift.decl.var.instance';
+    let DeclVarLocal: 'source.lang.swift.decl.var.local';
+
+    let RefAssociatedtype: 'source.lang.swift.ref.associatedtype';
+    let RefClass: 'source.lang.swift.ref.class';
+    let RefEnum: 'source.lang.swift.ref.enum';
+    let RefEnumelement: 'source.lang.swift.ref.enumelement';
+    let RefGenericTypeParam: 'source.lang.swift.ref.generic_type_param';
+    let RefProtocol: 'source.lang.swift.ref.protocol';
+    let RefStruct: 'source.lang.swift.ref.struct';
+    let RefTypealias: 'source.lang.swift.ref.typealias';
+
+    let RefFunctionConstructor: 'source.lang.swift.ref.function.constructor';
+    let RefFunctionFree: 'source.lang.swift.ref.function.free';
+    let RefFunctionSubscript: 'source.lang.swift.ref.function.subscript';
+
+    let RefFunctionMethodClass: 'source.lang.swift.ref.function.method.class';
+    let RefFunctionMethodInstance: 'source.lang.swift.ref.function.method.instance';
+
+    let RefFunctionOperatorInfix: 'source.lang.swift.ref.function.operator.infix';
+
+    let RefVarGlobal: 'source.lang.swift.ref.var.global';
+    let RefVarInstance: 'source.lang.swift.ref.var.instance';
+    let RefVarLocal: 'source.lang.swift.ref.var.local';
+
+    let SyntaxtypeArgument: 'source.lang.swift.syntaxtype.argument';
+    let SyntaxtypeComment: 'source.lang.swift.syntaxtype.comment';
+    let SyntaxtypeIdentifier: 'source.lang.swift.syntaxtype.identifier';
+    let SyntaxtypeKeyword: 'source.lang.swift.syntaxtype.keyword';
+    let SyntaxtypeNumber: 'source.lang.swift.syntaxtype.number';
+    let SyntaxtypeParameter: 'source.lang.swift.syntaxtype.parameter';
+
+    let SyntaxtypeAttributeBuiltin: 'source.lang.swift.syntaxtype.attribute.builtin';
+}
+
+export namespace Swift {
+
+    /**
+     * Maps SourceKit types to VSCode {SymbolKind}
+     * FIXME: kinda limted
+     *
+     * @export
+     * @param {SwiftType} swiftType
+     * @returns {SymbolKind}
+     */
+    export function symbolKindForSwiftType(swiftType: String): SymbolKind {
+        // not really easy to have an obvious completion kind per type.
+
+        switch (swiftType) {
+            // high confidence
+            case Swift.DeclModule:
+                return SymbolKind.Module;
+            case Swift.DeclEnum:
+            case Swift.DeclEnumelement:
+            case Swift.RefEnum:
+            case Swift.RefEnumelement:
+                return SymbolKind.Enum;
+            // medium confidence
+            case Swift.DeclFunctionFree:
+            case Swift.DeclFunctionSubscript:
+            case Swift.DeclFunctionOperatorInfix:
+            case Swift.RefFunctionFree:
+            case Swift.RefFunctionSubscript:
+            case Swift.RefFunctionOperatorInfix:
+                return SymbolKind.Function;
+            case Swift.DeclFunctionMethodClass:
+            case Swift.DeclFunctionMethodStatic:
+            case Swift.DeclFunctionMethodInstance:
+                return SymbolKind.Method;
+            case Swift.DeclFunctionConstructor:
+            case Swift.RefFunctionConstructor:
+                return SymbolKind.Constructor;
+            case Swift.DeclFunctionAccessorGetter:
+            case Swift.DeclFunctionAccessorSetter:
+                return SymbolKind.Field;
+            case Swift.DeclAssociatedtype:
+            case Swift.DeclClass:
+            case Swift.DeclStruct:
+            case Swift.DeclExtensionClass:
+            case Swift.RefClass:
+            case Swift.RefStruct:
+                return SymbolKind.Class;
+            case Swift.RefFunctionMethodClass:
+            case Swift.RefFunctionMethodInstance:
+                return SymbolKind.Method;
+            // low confidence
+            case Swift.DeclVarGlobal:
+            case Swift.DeclVarInstance:
+            case Swift.DeclVarLocal:
+            case Swift.RefVarGlobal:
+            case Swift.RefVarInstance:
+            case Swift.RefVarLocal:
+                return SymbolKind.Variable;
+            case Swift.SyntaxtypeArgument:
+            case Swift.SyntaxtypeParameter:
+                return SymbolKind.Field;
+            case Swift.RefAssociatedtype:
+            case Swift.DeclGenericTypeParam:
+            case Swift.RefGenericTypeParam:
+            case Swift.RefProtocol:
+            case Swift.RefTypealias:
+            case Swift.DeclProtocol:
+            case Swift.DeclTypealias:
+                return SymbolKind.Interface;
+
+            // no super applicable types for these:
+            case Swift.Keyword:
+            case Swift.SyntaxtypeKeyword:
+            case Swift.SyntaxtypeAttributeBuiltin:
+            case Swift.SyntaxtypeComment:
+            case Swift.SyntaxtypeIdentifier:
+            case Swift.SyntaxtypeNumber:
+                console.log("no match for " + swiftType);
+        };
+        return SymbolKind.Variable;
     };
-    return SymbolKind.Variable;
-};
 
-/**
- * Maps SourceKit types to VSCode {CompletionItemKind}
- * FIXME: kinda limted
- *
- * @export
- * @param {SwiftType} swiftType
- * @returns {CompletionItemKind}
- */
-export function completionKindForSwiftType(swiftType: SwiftType): CompletionItemKind {
-    // not really easy to have an obvious completion kind per type.
-    switch (swiftType) {
-// high confidence
-        case Decl.Module:
-            return CompletionItemKind.Module;
-        case Swift.Keyword:
-        case Syntaxtype.Keyword:
-            return CompletionItemKind.Keyword;
-        case SyntaxtypeAttribute.Builtin:
-            return CompletionItemKind.Text;
-        case Decl.Enum:
-        case Decl.Enumelement:
-        case Ref.Enum:
-        case Ref.Enumelement:
-            return CompletionItemKind.Enum;
-// medium confidence
-        case DeclFunction.Free:
-        case DeclFunction.Subscript:
-        case DeclFunctionOperator.Infix:
-        case RefFunction.Free:
-        case RefFunction.Subscript:
-        case RefFunctionOperator.Infix:
-            return CompletionItemKind.Function;
-        case DeclFunctionMethod.Class:
-        case DeclFunctionMethod.Static:
-        case DeclFunctionMethod.Instance:
-            return CompletionItemKind.Method;
-        case DeclFunction.Constructor:
-        case RefFunction.Constructor:
-            return CompletionItemKind.Constructor;
-        case DeclFunctionAccessor.Getter:
-        case DeclFunctionAccessor.Setter:
-            return CompletionItemKind.Field;
-        case Decl.Associatedtype:
-        case Decl.Class:
-        case Decl.Struct:
-        case DeclExtension.Class:
-        case Ref.Class:
-        case Ref.Struct:
-            return CompletionItemKind.Class;
-        case RefFunctionMethod.Class:
-        case RefFunctionMethod.Instance:
-            return CompletionItemKind.Method;
-// low confidence
-        case DeclVar.Global:
-        case DeclVar.Instance:
-        case DeclVar.Local:
-        case RefVar.Global:
-        case RefVar.Instance:
-        case RefVar.Local:
-            return CompletionItemKind.Variable;
-        case Syntaxtype.Argument:
-        case Syntaxtype.Parameter:
-            return CompletionItemKind.Field;
-        case Ref.Associatedtype:
-        case Decl.GenericTypeParam:
-        case Ref.GenericTypeParam:
-        case Ref.Protocol:
-        case Ref.Typealias:
-        case Decl.Protocol:
-        case Decl.Typealias:
-            return CompletionItemKind.Reference;
-        case Syntaxtype.Comment:
-            return CompletionItemKind.Text;
-        case Syntaxtype.Identifier:
-            return CompletionItemKind.Keyword;
-        case Syntaxtype.Number:
-            return CompletionItemKind.Value;
+    /**
+     * Maps SourceKit types to VSCode {CompletionItemKind}
+     * FIXME: kinda limted
+     *
+     * @export
+     * @param {SwiftType} swiftType
+     * @returns {CompletionItemKind}
+     */
+    export function completionKindForSwiftType(swiftType: String): CompletionItemKind {
+        // not really easy to have an obvious completion kind per type.
+        switch (swiftType) {
+            // high confidence
+            case Swift.DeclModule:
+                return CompletionItemKind.Module;
+            case Swift.Keyword:
+            case Swift.SyntaxtypeKeyword:
+                return CompletionItemKind.Keyword;
+            case Swift.SyntaxtypeAttributeBuiltin:
+                return CompletionItemKind.Text;
+            case Swift.DeclEnum:
+            case Swift.DeclEnumelement:
+            case Swift.RefEnum:
+            case Swift.RefEnumelement:
+                return CompletionItemKind.Enum;
+            // medium confidence
+            case Swift.DeclFunctionFree:
+            case Swift.DeclFunctionSubscript:
+            case Swift.DeclFunctionOperatorInfix:
+            case Swift.RefFunctionFree:
+            case Swift.RefFunctionSubscript:
+            case Swift.RefFunctionOperatorInfix:
+                return CompletionItemKind.Function;
+            case Swift.DeclFunctionMethodClass:
+            case Swift.DeclFunctionMethodStatic:
+            case Swift.DeclFunctionMethodInstance:
+                return CompletionItemKind.Method;
+            case Swift.DeclFunctionConstructor:
+            case Swift.RefFunctionConstructor:
+                return CompletionItemKind.Constructor;
+            case Swift.DeclFunctionAccessorGetter:
+            case Swift.DeclFunctionAccessorSetter:
+                return CompletionItemKind.Field;
+            case Swift.DeclAssociatedtype:
+            case Swift.DeclClass:
+            case Swift.DeclStruct:
+            case Swift.DeclExtensionClass:
+            case Swift.RefClass:
+            case Swift.RefStruct:
+                return CompletionItemKind.Class;
+            case Swift.RefFunctionMethodClass:
+            case Swift.RefFunctionMethodInstance:
+                return CompletionItemKind.Method;
+            // low confidence
+            case Swift.DeclVarGlobal:
+            case Swift.DeclVarInstance:
+            case Swift.DeclVarLocal:
+            case Swift.RefVarGlobal:
+            case Swift.RefVarInstance:
+            case Swift.RefVarLocal:
+                return CompletionItemKind.Variable;
+            case Swift.SyntaxtypeArgument:
+            case Swift.SyntaxtypeParameter:
+                return CompletionItemKind.Field;
+            case Swift.RefAssociatedtype:
+            case Swift.DeclGenericTypeParam:
+            case Swift.RefGenericTypeParam:
+            case Swift.RefProtocol:
+            case Swift.RefTypealias:
+            case Swift.DeclProtocol:
+            case Swift.DeclTypealias:
+                return CompletionItemKind.Reference;
+            case Swift.SyntaxtypeComment:
+                return CompletionItemKind.Text;
+            case Swift.SyntaxtypeIdentifier:
+                return CompletionItemKind.Keyword;
+            case Swift.SyntaxtypeNumber:
+                return CompletionItemKind.Value;
+            default:
+                console.log("un registered type" + swiftType);
 
+        };
+        return CompletionItemKind.Variable;
     };
-    return CompletionItemKind.Variable;
 };
-
 /**
  *
  * Wrapper around sourcekitten output items.
  * @export
  * @interface SwiftCompletionSuggestion
+ * ```json
+ * {
+    "descriptionKey" : "sendfile(Int32, Int32, off_t, UnsafeMutablePointer<off_t>!, UnsafeMutablePointer<sf_hdtr>!, Int32)",
+    "associatedUSRs" : "c:@F@sendfile",
+    "kind" : "source.lang.swift.decl.function.free",
+    "sourcetext" : "sendfile(<#T##Int32#>, <#T##Int32#>, <#T##off_t#>, <#T##UnsafeMutablePointer<off_t>!#>, <#T##UnsafeMutablePointer<sf_hdtr>!#>, <#T##Int32#>)",
+    "context" : "source.codecompletion.context.othermodule",
+    "typeName" : "Int32",
+    "moduleName" : "Darwin.POSIX.sys.socket",
+    "name" : "sendfile()"
+    }
+ * ```
  */
 export interface SwiftCompletionSuggestion {
 	/**
 	 * @type {string}
 	 */
-	name: string,
+    name: string,
 	/**
 	 * @type {string}
 	 */
-	descriptionKey: string,
+    descriptionKey: string,
 	/**
 	 * @type {string}
 	 */
-	sourcetext: string,
+    sourcetext: string,
 	/**
 	 * @type {SwiftType}
 	 */
-	kind: SwiftType,
+    kind: string,
 	/**
 	 * @type {string}
 	 */
-	typeName: string,
+    typeName: string,
 	/**
 	 * @type {string}
 	 */
-	moduleName: string,
+    moduleName: string,
 	/**
 	 * @type {string}
 	 */
-	associatedUSRs: string,
+    associatedUSRs: string,
 	/**
 	 * @type {string}
 	 */
-	context: string,
+    context: string,
 	/**
 	 * @type {string}
 	 */
-	docBrief: string,
+    docBrief: string,
 };

--- a/vscode-swift-language-server/src/swiftSourceTypes.ts
+++ b/vscode-swift-language-server/src/swiftSourceTypes.ts
@@ -1,0 +1,306 @@
+import 	{ SymbolKind, CompletionItemKind,
+} from 'vscode-languageserver';
+
+/**
+ *  Bindings for SourceKit type definitions
+ */
+export enum Keyword {
+    Keyword, 'source.lang.swift.keyword',
+};
+export enum Decl {
+    Associatedtype, 'source.lang.swift.decl.associatedtype',
+    Class, 'source.lang.swift.decl.class',
+    Enum, 'source.lang.swift.decl.enum',
+    Enumelement, 'source.lang.swift.decl.enumelement',
+    GenericTypeParam, 'source.lang.swift.decl.generic_type_param',
+    Protocol, 'source.lang.swift.decl.protocol',
+    Struct, 'source.lang.swift.decl.struct',
+    Typealias, 'source.lang.swift.decl.typealias',
+    Module, 'source.lang.swift.decl.module',
+};
+export enum DeclExtension {
+    Class, 'source.lang.swift.decl.extension.class',
+};
+export enum DeclFunction {
+    Constructor, 'source.lang.swift.decl.function.constructor',
+    Free, 'source.lang.swift.decl.function.free',
+    Subscript, 'source.lang.swift.decl.function.subscript',
+};
+export enum DeclFunctionOperator {
+    Infix, 'source.lang.swift.decl.function.operator.infix',
+};
+export enum DeclFunctionAccessor {
+    Getter, 'source.lang.swift.decl.function.accessor.getter',
+    Setter, 'source.lang.swift.decl.function.accessor.setter',
+};
+export enum DeclFunctionMethod {
+    Class, 'source.lang.swift.decl.function.method.class',
+    Instance, 'source.lang.swift.decl.function.method.instance',
+    Static, 'source.lang.swift.decl.function.method.static',
+};
+export enum DeclVar {
+    Global, 'source.lang.swift.decl.var.global',
+    Instance, 'source.lang.swift.decl.var.instance',
+    Local, 'source.lang.swift.decl.var.local',
+};
+export enum Ref {
+    Associatedtype, 'source.lang.swift.ref.associatedtype',
+    Class, 'source.lang.swift.ref.class',
+    Enum, 'source.lang.swift.ref.enum',
+    Enumelement, 'source.lang.swift.ref.enumelement',
+    GenericTypeParam, 'source.lang.swift.ref.generic_type_param',
+    Protocol, 'source.lang.swift.ref.protocol',
+    Struct, 'source.lang.swift.ref.struct',
+    Typealias, 'source.lang.swift.ref.typealias',
+};
+export enum RefFunction {
+    Constructor, 'source.lang.swift.ref.function.constructor',
+    Free, 'source.lang.swift.ref.function.free',
+    Subscript, 'source.lang.swift.ref.function.subscript',
+};
+export enum RefFunctionMethod {
+    Class, 'source.lang.swift.ref.function.method.class',
+    Instance, 'source.lang.swift.ref.function.method.instance',
+};
+export enum RefFunctionOperator {
+    Infix, 'source.lang.swift.ref.function.operator.infix'
+};
+export enum RefVar {
+    Global, 'source.lang.swift.ref.var.global',
+    Instance, 'source.lang.swift.ref.var.instance',
+    Local, 'source.lang.swift.ref.var.local',
+};
+export enum Syntaxtype {
+    Argument, 'source.lang.swift.syntaxtype.argument',
+    Comment, 'source.lang.swift.syntaxtype.comment',
+    Identifier, 'source.lang.swift.syntaxtype.identifier',
+    Keyword, 'source.lang.swift.syntaxtype.keyword',
+    Number, 'source.lang.swift.syntaxtype.number',
+    Parameter, 'source.lang.swift.syntaxtype.parameter',
+};
+export enum SyntaxtypeAttribute {
+    Builtin, 'source.lang.swift.syntaxtype.attribute.builtin',
+};
+
+export type SwiftType =
+    Keyword |
+    Decl |
+    DeclExtension |
+    DeclFunction |
+    DeclFunctionOperator |
+    DeclFunctionAccessor |
+    DeclFunctionMethod |
+    DeclVar |
+    Ref |
+    RefFunction |
+    RefFunctionMethod |
+    RefFunctionOperator |
+    RefVar |
+    Syntaxtype |
+    SyntaxtypeAttribute;
+
+/**
+ * Maps SourceKit types to VSCode {SymbolKind}
+ * FIXME: kinda limted
+ *
+ * @export
+ * @param {SwiftType} swiftType
+ * @returns {SymbolKind}
+ */
+export function symbolKindForSwiftType(swiftType: SwiftType): SymbolKind {
+    // not really easy to have an obvious completion kind per type.
+    switch (swiftType) {
+// high confidence
+        case Decl.Module:
+            return SymbolKind.Module;
+        case Decl.Enum:
+        case Decl.Enumelement:
+        case Ref.Enum:
+        case Ref.Enumelement:
+            return SymbolKind.Enum;
+// medium confidence
+        case DeclFunction.Free:
+        case DeclFunction.Subscript:
+        case DeclFunctionOperator.Infix:
+        case RefFunction.Free:
+        case RefFunction.Subscript:
+        case RefFunctionOperator.Infix:
+            return SymbolKind.Function;
+        case DeclFunctionMethod.Class:
+        case DeclFunctionMethod.Static:
+        case DeclFunctionMethod.Instance:
+            return SymbolKind.Method;
+        case DeclFunction.Constructor:
+        case RefFunction.Constructor:
+            return SymbolKind.Constructor;
+        case DeclFunctionAccessor.Getter:
+        case DeclFunctionAccessor.Setter:
+            return SymbolKind.Field;
+        case Decl.Associatedtype:
+        case Decl.Class:
+        case Decl.Struct:
+        case DeclExtension.Class:
+        case Ref.Class:
+        case Ref.Struct:
+            return SymbolKind.Class;
+        case RefFunctionMethod.Class:
+        case RefFunctionMethod.Instance:
+            return SymbolKind.Method;
+// low confidence
+        case DeclVar.Global:
+        case DeclVar.Instance:
+        case DeclVar.Local:
+        case RefVar.Global:
+        case RefVar.Instance:
+        case RefVar.Local:
+            return SymbolKind.Variable;
+        case Syntaxtype.Argument:
+        case Syntaxtype.Parameter:
+            return SymbolKind.Field;
+        case Ref.Associatedtype:
+        case Decl.GenericTypeParam:
+        case Ref.GenericTypeParam:
+        case Ref.Protocol:
+        case Ref.Typealias:
+        case Decl.Protocol:
+        case Decl.Typealias:
+            return SymbolKind.Interface;
+
+// no super applicable types for these:
+        case Keyword.Keyword:
+        case Syntaxtype.Keyword:
+        case SyntaxtypeAttribute.Builtin:
+        case Syntaxtype.Comment:
+        case Syntaxtype.Identifier:
+        case Syntaxtype.Number:
+            console.log("no match for " + swiftType);
+    };
+    return SymbolKind.Variable;
+};
+
+/**
+ * Maps SourceKit types to VSCode {CompletionItemKind}
+ * FIXME: kinda limted
+ *
+ * @export
+ * @param {SwiftType} swiftType
+ * @returns {CompletionItemKind}
+ */
+export function completionKindForSwiftType(swiftType: SwiftType): CompletionItemKind {
+    // not really easy to have an obvious completion kind per type.
+    switch (swiftType) {
+// high confidence
+        case Decl.Module:
+            return CompletionItemKind.Module;
+        case Keyword.Keyword:
+        case Syntaxtype.Keyword:
+            return CompletionItemKind.Keyword;
+        case SyntaxtypeAttribute.Builtin:
+            return CompletionItemKind.Text;
+        case Decl.Enum:
+        case Decl.Enumelement:
+        case Ref.Enum:
+        case Ref.Enumelement:
+            return CompletionItemKind.Enum;
+// medium confidence
+        case DeclFunction.Free:
+        case DeclFunction.Subscript:
+        case DeclFunctionOperator.Infix:
+        case RefFunction.Free:
+        case RefFunction.Subscript:
+        case RefFunctionOperator.Infix:
+            return CompletionItemKind.Function;
+        case DeclFunctionMethod.Class:
+        case DeclFunctionMethod.Static:
+        case DeclFunctionMethod.Instance:
+            return CompletionItemKind.Method;
+        case DeclFunction.Constructor:
+        case RefFunction.Constructor:
+            return CompletionItemKind.Constructor;
+        case DeclFunctionAccessor.Getter:
+        case DeclFunctionAccessor.Setter:
+            return CompletionItemKind.Field;
+        case Decl.Associatedtype:
+        case Decl.Class:
+        case Decl.Struct:
+        case DeclExtension.Class:
+        case Ref.Class:
+        case Ref.Struct:
+            return CompletionItemKind.Class;
+        case RefFunctionMethod.Class:
+        case RefFunctionMethod.Instance:
+            return CompletionItemKind.Method;
+// low confidence
+        case DeclVar.Global:
+        case DeclVar.Instance:
+        case DeclVar.Local:
+        case RefVar.Global:
+        case RefVar.Instance:
+        case RefVar.Local:
+            return CompletionItemKind.Variable;
+        case Syntaxtype.Argument:
+        case Syntaxtype.Parameter:
+            return CompletionItemKind.Field;
+        case Ref.Associatedtype:
+        case Decl.GenericTypeParam:
+        case Ref.GenericTypeParam:
+        case Ref.Protocol:
+        case Ref.Typealias:
+        case Decl.Protocol:
+        case Decl.Typealias:
+            return CompletionItemKind.Reference;
+        case Syntaxtype.Comment:
+            return CompletionItemKind.Text;
+        case Syntaxtype.Identifier:
+            return CompletionItemKind.Keyword;
+        case Syntaxtype.Number:
+            return CompletionItemKind.Value;
+
+    };
+    return CompletionItemKind.Variable;
+};
+
+/**
+ *
+ * Wrapper around sourcekitten output items.
+ * @export
+ * @interface SwiftCompletionSuggestion
+ */
+export interface SwiftCompletionSuggestion {
+	/**
+	 * @type {string}
+	 */
+	name: string,
+	/**
+	 * @type {string}
+	 */
+	descriptionKey: string,
+	/**
+	 * @type {string}
+	 */
+	sourcetext: string,
+	/**
+	 * @type {SwiftType}
+	 */
+	kind: SwiftType,
+	/**
+	 * @type {string}
+	 */
+	typeName: string,
+	/**
+	 * @type {string}
+	 */
+	moduleName: string,
+	/**
+	 * @type {string}
+	 */
+	associatedUSRs: string,
+	/**
+	 * @type {string}
+	 */
+	context: string,
+	/**
+	 * @type {string}
+	 */
+	docBrief: string,
+};


### PR DESCRIPTION
I had worked on a similar extension, but never pushed it to the market place. The server approach is waayy better than just exec-ing out to sourcekitten via client extension (large buffers required and slow performance with that approach) like I did. And thought you might want to check out some of fruits of my labor. 

You can check out the issues I opened at https://github.com/aaroncrespo/swift-vscode for some wishlists I had about making the completions better for certain cursor locations.

In the PR:
- Typed enum mapping for sourcekit types.
- Completion via snippets (like Xcode) 
- I also switched to use `description key` instead of `name` having the type info can be handy.

See screenshots:

<img width="306" alt="screen shot 2016-07-28 at 7 37 37 pm" src="https://cloud.githubusercontent.com/assets/431662/17233171/967f250a-54fb-11e6-96c7-f0559ca05e15.png">
*note the double quotes you see here are not an issue in this code.
<img width="276" alt="screen shot 2016-07-28 at 7 36 54 pm" src="https://cloud.githubusercontent.com/assets/431662/17233189/ce87b30e-54fb-11e6-9b82-647c364c2274.png">

I'm not the experienced with typescript, I would have preferred the mappings types for the source kit declarations to be tapped more narrowly than strings. 

Decls may not be 100% exhaustive and might change in a few months.
