### PR TITLE
Multi-file Support

### DIFF
--- a/vscode-swift-language-server/package.json
+++ b/vscode-swift-language-server/package.json
@@ -14,7 +14,7 @@
         "vscode-languageserver": "^2.2.1"
     },
     "devDependencies": {
-        "typescript": "^1.8.10",
+        "typescript": "1.8.7",
         "vscode": "^0.11.14"
     },
     "scripts": {

--- a/vscode-swift-language-server/src/projectSources.ts
+++ b/vscode-swift-language-server/src/projectSources.ts
@@ -1,0 +1,88 @@
+import {
+    IConnection,
+    TextDocument,
+    DidChangeWatchedFilesParams,
+    FileChangeType
+} from 'vscode-languageserver';
+
+import {
+    swiftSourcesIn,
+    stat,
+    convertFileToTextDocument
+} from './sourceSwiftInProject';
+
+const uriPrefix = 'file://';
+
+/**
+ * Remove the prefix, if present, from a string and return the new string.
+ *
+ * @return The string argument without the prefix. If the string does not contain the prefix no
+ * modification was made.
+ */
+function removePrefixFrom(string: string, prefix: string): string {
+    if (string.startsWith(prefix)) {
+        return string.substring(prefix.length);
+    } else {
+        return string;
+    }
+}
+
+/**
+ * A simple manager for the Swift sources in the workspace.
+ */
+export class ProjectSources {
+    private _projectURI: string;
+    private _sources: Map<string, TextDocument>;
+
+    /**
+     * Create a new `ProjectSources` instance to manage the sources for.
+     * @param projectURI The URI to the project workspace.
+     */
+    constructor(projectURI: string) {
+        this._projectURI = removePrefixFrom(projectURI, uriPrefix);
+        this._sources = new Map<string, TextDocument>();
+
+        swiftSourcesIn(this._projectURI).then((documents) => {
+            for (let document of documents) {
+                this._sources.set(document.uri, document);
+            }
+        });
+    }
+
+    /**
+     * Returns the URIs of all text documents managed by this instance.
+     *
+     * @return the URI's of all Swift source documents.
+     */
+    public getAllURIs(): string[] {
+        return Array.from(this._sources.keys());
+    }
+
+    /**
+     * Listens for low level notification on the given connection to
+     * update the text documents managed by this instance.
+     *
+     * @param connection The connection to listen on.
+     */
+    public listen(connection: IConnection): void {
+        // This change watcher is looking for modifications to Swift source files
+        // in the project workspace. It attempts to keep the `workspaceDocuments`
+        // Map in sync with the actual files in the workspace.
+        connection.onDidChangeWatchedFiles((change) => {
+            for (let event of change.changes) {
+                let uriWithoutPrefix = removePrefixFrom(event.uri, uriPrefix);
+                switch (event.type) {
+                    case FileChangeType.Created:
+                        let applyToMap = this._sources.set.bind(this._sources, uriWithoutPrefix);
+                        stat(uriWithoutPrefix)
+                            .then(convertFileToTextDocument)
+                            .then(applyToMap);
+                        break;
+                    case FileChangeType.Deleted:
+                        this._sources.delete(uriWithoutPrefix)
+                        break;
+                }
+            }
+        });
+    }
+}

--- a/vscode-swift-language-server/src/sourceSwiftInProject.ts
+++ b/vscode-swift-language-server/src/sourceSwiftInProject.ts
@@ -1,0 +1,112 @@
+import * as fs from 'fs';
+import * as Path from 'path';
+import { TextDocument } from 'vscode-languageserver';
+
+interface File {
+    uri: string;
+    stat: fs.Stats;
+}
+
+/**
+ * Closure to check if a File instance is a Swift source.
+ *
+ * A Swift source is a file that is a file on the filesystem and has a .swift extension.
+ */
+let isSwiftSource = (file: File): boolean => {
+    return file.stat.isFile() && file.uri.endsWith('.swift');
+}
+
+/**
+ * Closure to check if a File instance is a directory.
+ */
+let isDirectory = (file: File): boolean => {
+    return file.stat.isDirectory();
+}
+
+/**
+ * Closure to convert a multi-dimensional array of Files to a single dimensional array.
+ */
+let flatten = (array: File[][]): File[] => {
+    return array.reduce((a, b) => { return a.concat(b); }, []);
+}
+
+/**
+ * Read the contents of a file and convert it to a TextDocument.
+ *
+ * @param file The file to convert to a TextDocument.
+ * @returns A TextDocument instance for a given file.
+ */
+export function convertFileToTextDocument(file: File): Promise<TextDocument> {
+    return new Promise((resolve, reject) => {
+        fs.readFile(file.uri, (err, data) => {
+            if (err) { reject(err); }
+            else {
+                let document = TextDocument.create(file.uri, 'swift', 0, data.toString('utf8'));
+                resolve(document);
+            }
+        });
+    });
+}
+
+/**
+ * Extract the file system statistics for a supplied file.
+ *
+ * @param path The file or directory to gather filesystem statistics about.
+ * @returns The file or directory's filesystem statistics.
+ */
+export function stat(path: string): Promise<File> {
+    return new Promise((resolve, reject) => {
+        fs.stat(path, (err, stats) => {
+            if (err) { reject(err); }
+            else {
+                resolve({ uri: path, stat: stats });
+            }
+        });
+    });
+}
+
+/**
+ * Recursively find all files and directories in a supplied directory.
+ *
+ * @param directory The directory to recursively search for files and directories.
+ * @returns A flattened collection of all the files and directories and their children.
+ */
+function statDirectory(directory: string): Promise<File[]> {
+    return new Promise((resolve, reject) => {
+        fs.readdir(directory, (err, files) => {
+            let allFiles: File[] = [];
+            let appendFiles = (files: File[]): Promise<File[]> => {
+                allFiles = allFiles.concat(files);
+                return Promise.resolve(files);
+            };
+            // TODO: Can we make the first map lazy?
+            let promises = files
+                .map((file) => { return Path.join(directory, file) })
+                .map(stat);
+            Promise.all(promises)
+                .then(appendFiles)
+                .then((files: File[]) => {
+                    let subDirectories = files.filter(isDirectory).map((file) => { return statDirectory(file.uri); });
+                    return Promise.all(subDirectories).then(flatten);
+                })
+                .then(appendFiles)
+                .then((files: File[]) => {
+                    resolve(allFiles);
+                })
+                .catch(reject);
+        });
+    });
+}
+
+/**
+ * Recursively find all the files with a Swift extension in a supplied directory.
+ *
+ * @param directory The directory to recursively search for Swift sources.
+ * @returns A flattened collection of all the Swift sources as TextDocument instances.
+ */
+export function swiftSourcesIn(directory: string): Promise<TextDocument[]> {
+    return statDirectory(directory).then((files: File[]) => {
+        return Promise.all(files.filter(isSwiftSource).map(convertFileToTextDocument))
+            .then(n => n);
+    });
+}

--- a/vscode-swift-language/src/extension.ts
+++ b/vscode-swift-language/src/extension.ts
@@ -2,7 +2,7 @@
 
 import * as Path from 'path';
 
-import { ExtensionContext } from 'vscode';
+import { workspace, ExtensionContext } from 'vscode';
 import { LanguageClient, LanguageClientOptions, TransportKind } from 'vscode-languageclient';
 
 // this method is called when your extension is activated
@@ -19,7 +19,8 @@ export function activate(context: ExtensionContext) {
     let clientOptions: LanguageClientOptions = {
         documentSelector: ['swift'],
         synchronize: {
-            configurationSection: 'swift'
+            configurationSection: 'swift',
+            fileEvents: workspace.createFileSystemWatcher('**/*.swift', false, true, false)
         }
     }
 


### PR DESCRIPTION
# Change Highlights
- Watch the workspace for changes to any file that ends with a `.swift` extension
- Keep a data structure, `ProjectSources`, that contains the URI to the workspace _and_ all the Swift sources within
- `ProjectSources` listens for updates to the workspace (e.g., add/deleted Swift sources) and updates its internal [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) of those sources
- Whenever code suggestions are requested all the files in the workspace are sent to SourceKitten as `compilerargs` this enables multi-file source completion

[**NOTE**: Had to roll back to TypeScript 1.8.7 due to a bug in 1.8.10 that they will not be releasing a fix for until 2.0.0.](https://github.com/Microsoft/TypeScript/issues/7566)

Fixes #7
