### PR TITLE
Allow compiling on latest typescript.

### DIFF
--- a/vscode-swift-language-server/package.json
+++ b/vscode-swift-language-server/package.json
@@ -14,7 +14,7 @@
         "vscode-languageserver": "^2.2.1"
     },
     "devDependencies": {
-        "typescript": "1.8.7",
+        "typescript": "^1.8.10",
         "vscode": "^0.11.14"
     },
     "scripts": {


### PR DESCRIPTION
Flashbacks of swift 1-1.n

Saw https://github.com/Microsoft/TypeScript/issues/7566 after I looking at why the typescript version was dropped. Temporarily(?) we we can fix this issue by reducing levels of indirection and helping out the type system manually.

Maybe this helps readability also.
