### PR TITLE
Fix startup on fresh checkout from master

### DIFF
--- a/vscode-swift-language/package.json
+++ b/vscode-swift-language/package.json
@@ -67,6 +67,6 @@
         "vscode": "^0.11.0"
     },
     "dependencies": {
-        "vscode-languageclient": "^2.3.0"
+        "vscode-languageclient": "~2.3.0"
     }
 }


### PR DESCRIPTION
Hi! I tried playing around with this project briefly, but the extension crashed with `Unsupported server configuartion...` on the first try in the debugger.

The problem seems to be that the `LanguageClient` constructor from `vscode-languageclient` changed between versions 2.3 and 2.4. While `package.json` lists `^2.3.0` as the version, this allows subsequent minor versions as well, so on a fresh `npm install` I got 2.4.x.

Restricting the dependency to `~2.3.0` (i.e. only patch upgrades allowed) in `package.json` fixed this for me, and I got some completions working (nice!) 😎 

Of course the code could also be fixed to work with 2.4.x but I didn't try that yet.
