### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         }
     ],
     "engines": {
-        "vscode": "^1.6.0"
+        "vscode": "^1.12.0"
     },
     "categories": [
         "Languages"
@@ -70,6 +70,6 @@
         "@types/mocha": "^2.2.32"
     },
     "dependencies": {
-        "vscode-languageclient": "~2.5.0"
+        "vscode-languageclient": "^3.3.0"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,10 @@ export function activate(context: ExtensionContext) {
     
     // client extensions configure their server
     let clientOptions: LanguageClientOptions = {
-        documentSelector: ['swift'],
+        documentSelector: [
+            { language: 'swift', scheme: 'file' },
+            { language: 'swift', scheme: 'untitled' }
+        ],
         synchronize: {
             configurationSection: 'swift',
             fileEvents: [


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for Swift, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has this extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).